### PR TITLE
Pull request for WAZO-3119-fix-mk-build-deps-with-bullseye

### DIFF
--- a/bin/xivo-build-tools
+++ b/bin/xivo-build-tools
@@ -64,6 +64,21 @@ cd_to_git_dir_package() {
     return 0
 }
 
+create_build_deps_dir() {
+    local package="$1"
+
+    local package_dir="${PACKAGES_DIR}/${package}"
+    cp -r "${package_dir}" "${package_dir}-build-deps"
+    return 0
+}
+
+cd_to_build_deps_dir() {
+    local package="$1"
+
+    cd_to_git_dir_package "${package}-build-deps"
+    return 0
+}
+
 git_remote_branch_exist() {
     local remote_branch="$1"
 
@@ -137,8 +152,12 @@ build_source_package() {
     local package="$1"
     local options="-d -k$GPG_KEY"
 
-    cd_to_git_dir_package $package
+    create_build_deps_dir $package
+    cd_to_build_deps_dir $package
     install_source_build_depends
+    cd -
+
+    cd_to_git_dir_package $package
     if debian/rules get-orig-source 2> /dev/null
     then
         echo "We have a get-orig-source"

--- a/bin/xivo-build-tools
+++ b/bin/xivo-build-tools
@@ -145,7 +145,7 @@ build_package_from_source() {
 
 install_source_build_depends() {
     sudo apt-get update
-    mk-build-deps --install --remove --tool 'apt-get --no-install-recommends --assume-yes' --root-cmd sudo
+    mk-build-deps --install --tool 'apt-get --no-install-recommends --assume-yes' --root-cmd sudo
 }
 
 build_source_package() {

--- a/etc/xivo-build-tools/config
+++ b/etc/xivo-build-tools/config
@@ -1,5 +1,5 @@
 DEBFULLNAME="Wazo Maintainers"
-DEBEMAIL="dev.wazo@gmail.com"
+DEBEMAIL="dev@wazo.community"
 MIRROR_DEFAULT="wazo-official"
 DISTRIBUTION_DEFAULT="master"
 GIT_BRANCH_DEFAULT="master"


### PR DESCRIPTION
## use mk-build-deps in another directory

why: mk-build-deps on bullseye use newer version of equivs that change a
behavior to always use dpkg-buildpackage. Then this command will
generate artefacts (.buildinfo and .changes files). Re-rerunning
dpkg-buildpackage (via debuild) will trigger an error because of those
files.

Splitting directory for those command let the environment clean for each
command

## do not remove .deb from build-deps

why: Now we use a clean directory to build deps, we do not need to
remove .deb file. It can be useful for debug or avoid confusion about
"Why removing .deb if it's isolate on its directory"

## update default DEBEMAIL for wazo.community